### PR TITLE
allow the eks service role to be passed in instead of created

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -11,22 +11,24 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-
+locals {
+  eks_service_role = var.eks_cluster_service_role != null ? var.eks_cluster_service_role : aws_iam_role.default
+}
 resource "aws_iam_role" "default" {
-  count              = local.enabled ? 1 : 0
+  count              = var.eks_cluster_service_role != null && local.enabled ? 1 : 0
   name               = module.label.id
   assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
   tags               = module.label.tags
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cluster_policy" {
-  count      = local.enabled ? 1 : 0
+  count      = var.eks_cluster_service_role != null && local.enabled ? 1 : 0
   policy_arn = format("arn:%s:iam::aws:policy/AmazonEKSClusterPolicy", join("", data.aws_partition.current.*.partition))
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_service_policy" {
-  count      = local.enabled ? 1 : 0
+  count      = var.eks_cluster_service_role != null && local.enabled ? 1 : 0
   policy_arn = format("arn:%s:iam::aws:policy/AmazonEKSServicePolicy", join("", data.aws_partition.current.*.partition))
   role       = join("", aws_iam_role.default.*.name)
 }
@@ -36,7 +38,7 @@ resource "aws_iam_role_policy_attachment" "amazon_eks_service_policy" {
 # Because of that, on a new AWS account (where load balancers have not been provisioned yet, `nginx-ingress` fails to provision a load balancer
 
 data "aws_iam_policy_document" "cluster_elb_service_role" {
-  count = local.enabled ? 1 : 0
+  count = var.eks_cluster_service_role != null && local.enabled ? 1 : 0
 
   statement {
     effect = "Allow"
@@ -52,7 +54,7 @@ data "aws_iam_policy_document" "cluster_elb_service_role" {
 }
 
 resource "aws_iam_role_policy" "cluster_elb_service_role" {
-  count  = local.enabled ? 1 : 0
+  count  = var.eks_cluster_service_role != null && local.enabled ? 1 : 0
   name   = module.label.id
   role   = join("", aws_iam_role.default.*.name)
   policy = join("", data.aws_iam_policy_document.cluster_elb_service_role.*.json)

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_eks_cluster" "default" {
   count                     = local.enabled ? 1 : 0
   name                      = module.label.id
   tags                      = module.label.tags
-  role_arn                  = join("", aws_iam_role.default.*.arn)
+  role_arn                  = local.eks_service_role.arn
   version                   = var.kubernetes_version
   enabled_cluster_log_types = var.enabled_cluster_log_types
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,7 +55,7 @@ output "eks_cluster_managed_security_group_id" {
 
 output "eks_cluster_role_arn" {
   description = "ARN of the EKS cluster IAM role"
-  value       = join("", aws_iam_role.default.*.arn)
+  value       = local.eks_service_role.arn
 }
 
 output "kubernetes_config_map_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "workers_role_arns" {
   default     = []
 }
 
+variable "eks_cluster_service_role" {
+  type        = string
+  description = "The entire output map of aws_iam_role for the eks service role, or leave blank to create one"
+  default     = null
+}
+
 variable "workers_security_group_ids" {
   type        = list(string)
   description = "Security Group IDs of the worker nodes"


### PR DESCRIPTION
## what
* Allows the role to be passed in via the eks_cluster_service_role 
## why
* The eks service role may already exist and therefore should not be created. 
## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

